### PR TITLE
Integrate macaroon verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,13 @@
   },
   "homepage": "https://github.com/Toshbrown/databox-store-blob#readme",
   "dependencies": {
+    "basic-auth": "^1.1.0",
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
+    "macaroons.js": "^0.3.6",
     "modclean": "",
     "nedb": "^1.8.0",
+    "path-to-regexp": "^1.7.0",
     "promise": "^7.1.1",
     "request": "^2.75.0",
     "ws": "^1.1.1"

--- a/src/macaroon-verifier.js
+++ b/src/macaroon-verifier.js
@@ -1,0 +1,103 @@
+var request = require('request');
+var basicAuth = require('basic-auth');
+var macaroons = require('macaroons.js');
+var pathToRegexp = require('path-to-regexp');
+
+
+/**
+ * @return {Promise} A promise that resolves with a shared secret gotten from the arbiter
+ */
+module.exports.getSecretFromArbiter = function(arbiterKey) {
+	return new Promise((resolve, reject) => {
+		if (!arbiterKey) {
+			resolve('');
+			return;
+		}
+
+		// TODO: Could just make it port 80 arbiter-side since permissions don't matter in the container anyway...
+		request('http://'+arbiterKey+'@arbiter:8080/store/secret', (error, response, body) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+
+			resolve(new Buffer(body, 'base64'));
+		});
+	});
+};
+
+
+/**
+ * @param {String} Arbiter shared secret key
+ * @param {String} Store hostname
+ * @return {Function} Macaroon verification middleware
+ */
+module.exports.verifier = function (secret, storeName) {
+
+	/**
+	 * Checks validity of the macaroon "path" caveat
+	 * @param {String} path
+	 * @param {String} caveat
+	 * @return {Boolean} valid
+	 */
+	var isPathtValid = function () {
+		var prefixRegex = /path = .*/;
+		var prefixLen   = 'path = '.length;
+
+		return function (caveat, path) {
+			if (!prefixRegex.test(caveat))
+				return false;
+
+			// TODO: Catch potential JSON.parse exception
+			return pathToRegexp(JSON.parse(caveat.substring(prefixLen).trim())).test(path);
+		}
+	}();
+
+	/**
+	 * Returns a verifier for a given path
+	 * @param {String} path
+	 * @return {Function} Path verifier
+	 */
+	var createPathVerifier = function (path) {
+		return function (caveat) {
+			return isPathValid(caveat, path);
+		};
+	};
+
+	return function (req, res, next) {
+		// TODO: Fail loudly if app is not using body-parser
+
+		// Extract token as per Hypercat PAS 212 7.1 for uniformity
+		var creds = basicAuth(req);
+		var macaroon = req.get('X-Api-Key') || (creds && creds.name);
+
+		if (!macaroon) {
+			res.status(401).send('Missing API key/token');
+			return;
+		}
+
+		//console.log("Macaroon serialized:", macaroon);
+
+		// Parse and verify macaroon
+		// TODO: Complain if there are issues deserializing it
+		macaroon = macaroons.MacaroonsBuilder.deserialize(req.body.macaroon);
+
+		//console.log("Macaroon deserialized:", macaroon.inspect());
+
+		macaroon = new macaroons.MacaroonsVerifier(macaroon);
+
+		// Verify "target" caveat
+		macaroon.satisfyExact("target = " + storeName);
+
+		macaroon.satisfyGeneral(createPathVerifier(req.path));
+
+		// TODO: Verify granularity etc here (or potentially in tandem with driver)?
+
+		if (!macaroon.isValid(secret)) {
+			res.status(401).send('Invalid API key/token');
+			return;
+		}
+
+		next();
+	};
+};

--- a/src/main.js
+++ b/src/main.js
@@ -5,42 +5,49 @@ var databox_directory = require("./utils/databox_directory.js");
 var timeseriesRouter = require('./timeseries.js');
 var keyValueRouter = require('./keyvalue.js');
 var actuateRouter = require('./actuate.js');
+var macaroonVerifier = require('./macaroon-verifier.js');
+
+var DATABOX_LOCAL_NAME = process.env.DATABOX_LOCAL_NAME;
+// TODO: Refactor token to key here and in CM to avoid confusion with bearer tokens
+var ARBITER_KEY = process.env.ARBITER_TOKEN;
+var NO_SECURITY = !!process.env.NO_SECURITY;
 
 var app = express();
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
 
-var DATABOX_LOCAL_NAME = process.env.DATABOX_LOCAL_NAME;
-
-//TODO app.use(Macaroon checker);
-
-app.get("/status", function(req, res) {
-    res.send("active");
+app.get('/status', function(req, res) {
+	res.send('active');
 });
 
-app.use('/api/actuate',actuateRouter(app));
+macaroonVerifier.getSecretFromArbiter(ARBITER_KEY)
 
-app.use('/:var(api/data|api/ts)?',timeseriesRouter(app));
+	.then((secret) => {
+		// TODO: Clean up
 
-app.use('/api/key',keyValueRouter(app));
+		if (!NO_SECURITY)
+			app.use(macaroonVerifier.verifier(secret, DATABOX_LOCAL_NAME));
 
+		app.use('/api/actuate',actuateRouter(app));
 
+		app.use('/:var(api/data|api/ts)?',timeseriesRouter(app));
 
-//Websocket connection to live stream data
-var server = require('http').createServer(app);
-var WebSocketServer = require('ws').Server
-app.wss = new WebSocketServer({ server: server })
-app.broadcastDataOverWebSocket = require('./broadcastDataOverWebSocket.js')(app)
+		app.use('/api/key',keyValueRouter(app));
 
+		//return databox_directory.register_datastore(DATABOX_LOCAL_NAME, ':8080/api');
+	})
 
-databox_directory.register_datastore(DATABOX_LOCAL_NAME, ':8080/api')
-  .then( (ids)=>{
-	   server.listen(8080);
-  })
-  .catch((err) => {
-  	console.log(err)
-  });
+	.then((ids) => {
+		//Websocket connection to live stream data
+		var server = require('http').createServer(app);
+		var WebSocketServer = require('ws').Server;
+		app.wss = new WebSocketServer({ server: server });
+		app.broadcastDataOverWebSocket = require('./broadcastDataOverWebSocket.js')(app);
 
- module.exports = app;
+		server.listen(8080);
+	})
 
+	.catch((err) => {
+		console.log(err);
+	});


### PR DESCRIPTION
Adds macaroon verification middleware that can be turned off with the environment variable `NO_SECURITY` for debug (//TODO: Update readme), and automatically gets a shared secret key from the arbiter on starting up. Responds with 401 for missing or invalid macaroon. Resolves #4.

Only two caveats are checked right now, `target` and `path` which are described in the papers and [random other places too](https://github.com/me-box/databox-arbiter/blob/hypercat/docs/further-info.md#macaroons).

I realised too late that I was building on master instead of the Hypercat branch, thinking I would put this in it's own branch. Since I don't have admin to this repo, could you create a branch called "macaroons" or so that I can modify this PR to merge to? Then I can fix `main.js` such that Hypercat can be merged to macaroons and everything is up to date.