### PR TITLE
Apply auth system to WebSocket connections

### DIFF
--- a/src/lib/websockets/broadcastDataOverWebSocket.js
+++ b/src/lib/websockets/broadcastDataOverWebSocket.js
@@ -6,9 +6,12 @@ module.exports = function (app) {
     var connectionsByKey = {};
 
     app.wss.on('connection', function connection(ws) {
-    
-        //TODO Macaroon check 
-    
+
+        // If the client made it this far, tha macaroon has already been verified an made available
+        var macaroon = ws.upgradeReq.macaroon;
+
+        console.log(macaroon.inspect());
+
         ws.on('message', function incoming(message) {
             console.log('received: %s', message);
             //TODO define msg format 

--- a/src/macaroon-verifier.js
+++ b/src/macaroon-verifier.js
@@ -1,3 +1,4 @@
+var url = require('url');
 var request = require('./lib/databox-request/databox-request.js')();
 var basicAuth = require('basic-auth');
 var macaroons = require('macaroons.js');
@@ -32,42 +33,43 @@ module.exports.getSecretFromArbiter = function(arbiterKey) {
 
 
 /**
+ * Checks validity of the macaroon "path" caveat
+ * @param {String} path
+ * @param {String} caveat
+ * @return {Boolean} valid
+ */
+var isPathValid = function () {
+	var prefixRegex = /path = .*/;
+	var prefixLen   = 'path = '.length;
+
+	return function (caveat, path) {
+		if (!prefixRegex.test(caveat))
+			return false;
+
+		// TODO: Catch potential JSON.parse exception
+		return pathToRegexp(JSON.parse(caveat.substring(prefixLen).trim())).test(path);
+	}
+}();
+
+/**
+ * Returns a verifier for a given path
+ * @param {String} path
+ * @return {Function} Path verifier
+ */
+var createPathVerifier = function (path) {
+	return function (caveat) {
+		return isPathValid(caveat, path);
+	};
+};
+
+
+/**
+ * Creates Macaroon verification middleware for express requests
  * @param {String} secret Arbiter shared secret key
  * @param {String} storeName Store hostname
  * @return {Function} Macaroon verification middleware
  */
 module.exports.verifier = function (secret, storeName) {
-
-	/**
-	 * Checks validity of the macaroon "path" caveat
-	 * @param {String} path
-	 * @param {String} caveat
-	 * @return {Boolean} valid
-	 */
-	var isPathValid = function () {
-		var prefixRegex = /path = .*/;
-		var prefixLen   = 'path = '.length;
-
-		return function (caveat, path) {
-			if (!prefixRegex.test(caveat))
-				return false;
-
-			// TODO: Catch potential JSON.parse exception
-			return pathToRegexp(JSON.parse(caveat.substring(prefixLen).trim())).test(path);
-		}
-	}();
-
-	/**
-	 * Returns a verifier for a given path
-	 * @param {String} path
-	 * @return {Function} Path verifier
-	 */
-	var createPathVerifier = function (path) {
-		return function (caveat) {
-			return isPathValid(caveat, path);
-		};
-	};
-
 	return function (req, res, next) {
 		// TODO: Fail loudly if app is not using body-parser
 
@@ -84,7 +86,7 @@ module.exports.verifier = function (secret, storeName) {
 
 		// Parse and verify macaroon
 		// TODO: Complain if there are issues deserializing it
-		macaroon = macaroons.MacaroonsBuilder.deserialize(req.body.macaroon);
+		macaroon = macaroons.MacaroonsBuilder.deserialize(macaroon);
 
 		//console.log("Macaroon deserialized:", macaroon.inspect());
 
@@ -103,5 +105,50 @@ module.exports.verifier = function (secret, storeName) {
 		}
 
 		next();
+	};
+};
+
+
+/**
+ * Creates Macaroon verification middleware for WebSocket connections
+ * @param {String} secret Arbiter shared secret key
+ * @param {String} storeName Store hostname
+ * @return {Function} WebSocket server client verifier
+ */
+module.exports.wsVerifier = function (secret, storeName) {
+	return function (info, callback) {
+		// Extract token as per Hypercat PAS 212 7.1 for uniformity
+		var creds = basicAuth(info);
+		var macaroon = info.req.headers['x-api-key'] || (creds && creds.name);
+
+		if (!macaroon) {
+			callback(false, 401, 'Missing API key/token');
+			return;
+		}
+
+		//console.log("Macaroon serialized:", macaroon);
+
+		// Parse and verify macaroon
+		// TODO: Complain if there are issues deserializing it
+		macaroon = macaroons.MacaroonsBuilder.deserialize(macaroon);
+
+		//console.log("Macaroon deserialized:", macaroon.inspect());
+
+		macaroon = new macaroons.MacaroonsVerifier(macaroon);
+
+		// Verify "target" caveat
+		macaroon.satisfyExact("target = " + storeName);
+
+		macaroon.satisfyGeneral(createPathVerifier(url.parse(info.req.url).pathname));
+
+		// TODO: Verify granularity etc here (or potentially in tandem with driver)?
+
+		if (!macaroon.isValid(secret)) {
+			callback(false, 401, 'Invalid API key/token');
+			return;
+		}
+
+		info.req.macaroon = macaroon;
+		callback(true);
 	};
 };

--- a/src/main.js
+++ b/src/main.js
@@ -83,9 +83,6 @@ macaroonVerifier.getSecretFromArbiter(ARBITER_KEY)
 		if (!NO_SECURITY)
 			app.use(macaroonVerifier.verifier(secret, DATABOX_LOCAL_NAME));		
 
-	})
-
-	.then((ids) => {
 		//Websocket connection to live stream data
         var WebSocketServer = require('ws').Server;
         app.wss = new WebSocketServer({ server: server, verifyClient: macaroonVerifier.wsVerifier(secret, DATABOX_LOCAL_NAME) });

--- a/src/main.js
+++ b/src/main.js
@@ -88,7 +88,7 @@ macaroonVerifier.getSecretFromArbiter(ARBITER_KEY)
 	.then((ids) => {
 		//Websocket connection to live stream data
         var WebSocketServer = require('ws').Server;
-        app.wss = new WebSocketServer({ server: server });
+        app.wss = new WebSocketServer({ server: server, verifyClient: macaroonVerifier.wsVerifier(secret, DATABOX_LOCAL_NAME) });
         app.broadcastDataOverWebSocket = require('./lib/websockets/broadcastDataOverWebSocket.js')(app);
 
 		server.listen(8080, function () {


### PR DESCRIPTION
Resolves part of #13. Also fixes a typo that made macaroons on normal endpoints get rejected.

This PR makes it so that WebSocket connections need to use the same authorization system as everything else. The actual WebSocket handshake itself will be rejected if the macaroon/token is missing or invalid, and will respond with the same 401 errors as with the REST endpoints. This is before the `connection` event even fires.

It is possible to check at the same time if the connection is secure (basically if `req.connection.authorized` or `req.connection.encrypted` is set) but I left that out for now as to not change too many things at once. So for now, insecure connections are accepted, but those can be rejected too, alongside the other conditions, with one extra line of code.

To app developers, this means that (for example in Node.js) instead of doing:

    var ws = new WebSocket('ws://storehostname:8080');

You can do one of either of these (structure as defined in section 7.1 of the [PAS 212](http://shop.bsigroup.com/upload/276778/PAS_212.pdf) and used everywhere else): 

    var ws = new WebSocket('ws://[serialized-macaroon]@storehostname:8080');
    // or
    var ws = new WebSocket('ws://storehostname:8080', null, { headers: {'X-Api-Key': '[serialized-macaroon]'}});

NB: Path caveats apply here, so access to WS needs explicit permission. I will elaborate more on this shortly. I deliberately left `broadcastDataOverWebSocket.js` untouched for the most part for now, since I'm about to propose something first in another issue before getting back to this.

TODO: Document all that for app devs somewhere.