### PR TITLE
Match API to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ This is beta. Expect bugs but the API should be reasonably stable.
 
     npm install && npm start
 
-#Devloping
+#Developing
 
 Start the container manger in developer mode:
 

--- a/src/main.js
+++ b/src/main.js
@@ -70,8 +70,8 @@ macaroonVerifier.getSecretFromArbiter(ARBITER_KEY)
 			path: '/ws'
 		}));
 
-		app.use('/read/ts/:cmd/:datasourceid',  timeseries.read());
-		app.use('/write/ts/:datasourceid', timeseries.write(subscriptionManager));
+		app.use('/read/ts/:datasourceid/:cmd', timeseries.read());
+		app.use('/write/ts/:datasourceid',     timeseries.write(subscriptionManager));
 
 		app.use('/read/json/:key',   keyvalue.read());
 		app.use('/write/json/:key',  keyvalue.write(subscriptionManager));

--- a/test/timeseries-data-since.js
+++ b/test/timeseries-data-since.js
@@ -28,7 +28,7 @@ describe('tests /read/ts/since', function() {
 
 	it('can get lastRecord',function(done){
 		supertest
-				.post("/read/ts/latest/"+11)
+				.post("/read/ts/"+11+'/latest')
 				.send(data)
 				.expect(200)
 				.end(function(err,result){
@@ -134,7 +134,7 @@ describe('tests /read/ts/since', function() {
 				};
 
 		supertest
-				.post("/read/ts/since/"+11)
+				.post("/read/ts/"+11+'/since')
 				.send(data)
 				.expect(200)
 				.end(function(err,result){
@@ -160,7 +160,7 @@ describe('tests /read/ts/range', function() {
 			}; 
 
 			supertest
-					.post("/read/ts/range/"+11)
+					.post("/read/ts/"+11+'/range')
 					.send(data)
 					.expect(200)
 					.end(function(err,result){

--- a/test/timeseries.js
+++ b/test/timeseries.js
@@ -22,7 +22,7 @@ describe('Add and retrieve latest TS values', function() {
 		var data = {
 		}; 
 		supertest
-			.post("/read/ts/latest/"+11)
+			.post("/read/ts/"+11+'/latest')
 			.send(data)
 			.expect(200)
 			.end(function(err,result){


### PR DESCRIPTION
@Toshbrown Thanks for updating documentation. This just makes the API match that, since one thing was reversed.

Should we rename `datasourceid` to just `id`? Then it would match `key` from the other API and also mean the same for sensing and actuating (since for actuating it's more of a sink than a source). Anyway, I'm just being pedantic; it's not super important.

As for the IDs themselves, are these always numerical? So that means that the driver assigns IDs and maps them to metadata including a human-readable name in their catalogue?