### PR TITLE
Api changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ Then restart the container manger to use you updated version.
 #Testing
 
     npm install --development 
-    npm test
+    NO_SECURITY=1 NO_LOGGING=1 npm test

--- a/README.md
+++ b/README.md
@@ -10,26 +10,24 @@ The datastore exposes an HTTP-based API on port 8080 and a WebSocket based API f
 #Read API 
 
 ###Time series data   
-    URL: /read/ts/<datasourceid>/latest
-    Method: POST
+    URL: /<datasourceid>/ts/latest
+    Method: GET
     Parameters: <datasourceid> the datasourceid to get data for.
     Notes: will return the latest data based on the datasourceid 
     
-    URL: /read/ts/<datasourceid>/since
-    Method: POST
-    Parameters: <datasourceid> the datasourceid to get data for.
-    Post data: Raw JSON body containing elements as follows {timestamp: <timestamp in ms>}
-    Notes: will return the all data since the provided timestamp for the databox wide sensor_id
+    URL: /<datasourceid>/ts/since/<timestamp>
+    Method: GET
+    Parameters: <datasourceid> the datasourceid to get data for. <timestamp> the timestamp in ms to return records after
+    Notes: will return the all data since the provided timestamp for the provided datasourceid
     
-    URL: /read/ts/<datasourceid>/range
-    Method: POST
-    Parameters: <datasourceid> the datasourceid to get data for.
-    Post data:  Raw JSON body containing elements as follows {start: <start timestamp>, end: <end timestamp>}
-    Notes: will return the all data since the provided timestamp for the databox wide sensor_id
+    URL: /<datasourceid>/range/<startTimestamp>/<endTimestamp>
+    Method: GET
+    Parameters: <datasourceid> the datasourceid to get data for, a start: <startTimestamp> and end: <endTimestamp> for the range.
+    Notes: will return the all data between the provided start and end timestamps for the provided datasourceid.
     
 ###Key value pairs
 
-    URL: /read/key/<key>
+    URL: /<key>/key/
     Method: GET
     Parameters: replace <key> with document key 
     Notes: will return the data stored with that key. Returns an empty array 404 {status:404,error:"Document not found."} if no data is stored
@@ -62,14 +60,14 @@ Connect to a websocket client to port 8080. Then subscribe for data using:
     Notes: This data is used to populate the Items in the Hypercat catalog. The datasourceid is managed by the driver and must be unique to this store. 
     
 ###Time series data
-    URL: /write/ts/<datasourceid>
+    URL: /<datasourceid>/ts/
     Method: POST
     Parameters: Raw JSON body containing elements as follows {data: <json blob to store>}
     Notes: Stores a value a timestamp is added on insertion
     
 ###Key value pairs
 
-    URL: /write/key/<key>
+    URL: /<key>/key/
     Method: POST
     Parameters: Raw JSON body containing elements as follows {<data to be stored in JSON format>}
     Notes: will insert if the <key> is not in the database and update the document if it is.

--- a/src/keyvalue.js
+++ b/src/keyvalue.js
@@ -7,7 +7,7 @@ db.ensureIndex({fieldName: 'datasource_id', unique: false});
 
 // TODO: Consider OOP-ing this whole thing
 
-module.exports.read = function () {
+module.exports.api = function (subscriptionManager) {
 	var router = Router({mergeParams: true});
 
 	// TODO: .all, see #15
@@ -31,19 +31,15 @@ module.exports.read = function () {
 		});
 	});
 
-	return router;
-};
-
-module.exports.write = function (subscriptionManager) {
-	var router = Router({mergeParams: true});
-
 	// TODO: .all, see #15
 	router.post('/', (req, res) => {
 		var key = req.params.key;
+		var data = req.body;
 		var doc = {
 			key: key,
-			data: req.body
+			data: data
 		};
+
 		db.update({ key }, doc, { upsert: true, returnUpdatedDocs: true }, function (err, numAffected, affectedDocuments, upsert) {
 			if (err) {
 				console.log("[Error]::", req.originalUrl, doc, err);
@@ -54,9 +50,8 @@ module.exports.write = function (subscriptionManager) {
 			res.send(affectedDocuments.data);
 		});
 
-		data.path = '/json/' + key;
-
-		subscriptionManager.emit(data.path, data);
+		var path = '/json/' + key;
+		subscriptionManager.emit(path, data);
 	});
 
 	return router;

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ const DATABOX_ARBITER_ENDPOINT = process.env.DATABOX_ARBITER_ENDPOINT || "https:
 // TODO: Refactor token to key here and in CM to avoid confusion with bearer tokens
 const ARBITER_KEY = process.env.ARBITER_TOKEN;
 const NO_SECURITY = !!process.env.NO_SECURITY;
+const NO_LOGGING = !!process.env.NO_LOGGING;
 
 const PORT = process.env.PORT || 8080;
 
@@ -49,8 +50,10 @@ macaroonVerifier.getSecretFromArbiter(ARBITER_KEY)
 		* Logs all requests and responses to/from the API in bunyan format in nedb
 		*/
 		
-		var databoxLogger = require('./lib/log/databox-log-middelware.js')();
-		app.use(databoxLogger);
+		if (!NO_LOGGING) {
+			var databoxLogger = require('./lib/log/databox-log-middelware.js')();
+			app.use(databoxLogger);
+		}
 
 		var server = null;
 		if(credentials.cert === '' || credentials.key === '') {

--- a/src/main.js
+++ b/src/main.js
@@ -72,11 +72,9 @@ macaroonVerifier.getSecretFromArbiter(ARBITER_KEY)
 			path: '/ws'
 		}));
 
-		app.use('/read/ts/:datasourceid/:cmd', timeseries.read());
-		app.use('/write/ts/:datasourceid',     timeseries.write(subscriptionManager));
+		app.use('/:datasourceid/ts/:cmd?/:timestamp?/:endtimestamp?', timeseries.api(subscriptionManager));
 
-		app.use('/read/json/:key',   keyvalue.read());
-		app.use('/write/json/:key',  keyvalue.write(subscriptionManager));
+		app.use('/:key/json/',   keyvalue.api(subscriptionManager));
 
 		app.use('/sub',   subscriptionManager.sub());
 		app.use('/unsub', subscriptionManager.unsub());

--- a/test/keyvalue.js
+++ b/test/keyvalue.js
@@ -16,9 +16,9 @@ describe('Add and retrieve by key', function() {
     var data2 = {test:"data", hello:"world", goodby:'world'}; 
     var key = Date.now();
 	
-    it("Handles invalid key on /read/json/", function(done) {
+    it("Handles invalid key on read /json", function(done) {
 		supertest
-			.get("/read/json/asdfgfhjkl")
+			.get("/asdfgfhjkl/json/")
 			.expect(500)
 			.end((err,result)=>{
 				//assert.deepEqual(result.body, {status:404,error:"Document not found."});
@@ -26,9 +26,9 @@ describe('Add and retrieve by key', function() {
 			});
 	})
 
-    it("Adds records posted to /write/json/:key", function(done) {
+    it("Adds records posted to :key/json/", function(done) {
 		supertest
-			.post("/write/json/"+key)
+			.post("/"+key+"/json/")
 			.send(data)
 			.expect(200)
 			.end((err,result)=>{
@@ -37,10 +37,10 @@ describe('Add and retrieve by key', function() {
 			});
 	})
 
-	it("retrieves latest records with /read/json/" + key, function(done) {
+	it("retrieves latest records with " + key + "/json/ ", function(done) {
 		
 		supertest
-			.get("/read/json/"+key)
+			.get("/"+key+"/json/")
 			.expect(200)
 			.end(function(err,result){
 				if(err) {
@@ -53,9 +53,9 @@ describe('Add and retrieve by key', function() {
 			});
 	});
 
-    it("Updates records posted to /write/json/:key", function(done) {
+    it("Updates records posted to :key/json", function(done) {
 		supertest
-			.post("/write/json/"+key)
+			.post("/"+key+"/json")
 			.send(data2)
 			.expect(200)
 			.end((err,result)=>{
@@ -64,10 +64,10 @@ describe('Add and retrieve by key', function() {
 			});
 	});
 
-    it("retrieves latest records with /read/json/" + key, function(done) {
+    it("retrieves latest records with /" + key + "/json/", function(done) {
 		
 		supertest
-			.get("/read/json/"+key)
+			.get("/"+key+"/json")
 			.expect(200)
 			.end(function(err,result){
 				if(err) {

--- a/test/timeseries-data-since.js
+++ b/test/timeseries-data-since.js
@@ -6,18 +6,18 @@ var assert = require('assert');
 
 var recordSet = []; // store res from can POST /data/since to test /data/range
 
-describe('tests /read/ts/since', function() {
+describe('tests /ts/since', function() {
 	var data = {
 	    	"data": {new:"data", since:"world"},
 		}; 
 	var lastRecord = {};
 	
-	it("Adds records posted to /write/ts", function(done) {
+	it("Adds records posted to :timestamp/ts", function(done) {
 		var data = {
 	    	"data": {test:"data", hello:"world"},
 		}; 
 		supertest
-			.post("/write/ts/"+11)
+			.post("/"+11+"/ts/")
 			.send(data)
 			.expect(200)
 			.end(function(err,result){
@@ -28,7 +28,7 @@ describe('tests /read/ts/since', function() {
 
 	it('can get lastRecord',function(done){
 		supertest
-				.post("/read/ts/"+11+'/latest')
+				.get("/"+11+'/ts/latest')
 				.send(data)
 				.expect(200)
 				.end(function(err,result){
@@ -43,12 +43,12 @@ describe('tests /read/ts/since', function() {
 				});
 	});
 
-	it("Adds records posted to /write/ts", function(done) {
+	it("Adds records posted to /ts", function(done) {
 		var data = {
 	    	"data": {test:"data", hello:"world"},
 		}; 
 		supertest
-			.post("/write/ts/"+11)
+			.post("/"+11+"/ts")
 			.send(data)
 			.expect(200)
 			.end(function(err,result){
@@ -57,12 +57,12 @@ describe('tests /read/ts/since', function() {
 			});
 	});
 
-	it("Adds records posted to /write/ts/", function(done) {
+	it("Adds records posted to /ts", function(done) {
 		var data = {
 	    	"data": {test:"data", hello:"world0"},
 		}; 
 		supertest
-			.post("/write/ts/"+11)
+			.post("/"+11+"/ts")
 			.send(data)
 			.expect(200)
 			.end(function(err,result){
@@ -71,12 +71,12 @@ describe('tests /read/ts/since', function() {
 			});
 	});
 
-	it("Adds records posted to /write/ts/", function(done) {
+	it("Adds records posted to /ts", function(done) {
 		var data = {
 	    	"data": {test:"data", hello:"world1"},
 		}; 
 		supertest
-			.post("/write/ts/"+11)
+			.post("/"+11+"/ts")
 			.send(data)
 			.expect(200)
 			.end(function(err,result){
@@ -85,12 +85,12 @@ describe('tests /read/ts/since', function() {
 			});
 	});
 
-	it("Adds records posted to /write/ts/", function(done) {
+	it("Adds records posted to /ts", function(done) {
 		var data = {
 	    	"data": {test:"data", hello:"world2"},
 		}; 
 		supertest
-			.post("/write/ts/"+11)
+			.post("/"+11+"/ts")
 			.send(data)
 			.expect(200)
 			.end(function(err,result){
@@ -99,12 +99,12 @@ describe('tests /read/ts/since', function() {
 			});
 	});
 
-	it("Adds records posted to /write/ts/", function(done) {
+	it("Adds records posted to /ts", function(done) {
 		var data = {
 	    	"data": {test:"data", hello:"world3"},
 		}; 
 		supertest
-			.post("/write/ts/"+11)
+			.post("/"+11+"/ts")
 			.send(data)
 			.expect(200)
 			.end(function(err,result){
@@ -113,12 +113,12 @@ describe('tests /read/ts/since', function() {
 			});
 	});
 
-	it("Adds records posted to /write/ts/", function(done) {
+	it("Adds records posted to /ts", function(done) {
 		var data = {
 	    	"data": {test:"data", hello:"world4"},
 		}; 
 		supertest
-			.post("/write/ts/"+11)
+			.post("/"+11+"/ts")
 			.send(data)
 			.expect(200)
 			.end(function(err,result){
@@ -127,15 +127,11 @@ describe('tests /read/ts/since', function() {
 			});
 	});
 
-	it('can POST /read/ts/since ' + lastRecord.timestamp  + ' and returns 6 items',function(done){
+	it('can POST /ts/since ' + lastRecord.timestamp  + ' and returns 6 items',function(done){
 		
-		data = {
-					"timestamp": lastRecord.timestamp,
-				};
-
+		
 		supertest
-				.post("/read/ts/"+11+'/since')
-				.send(data)
+				.get("/"+11+'/ts/since/'+lastRecord.timestamp)
 				.expect(200)
 				.end(function(err,result){
 					if(err) {
@@ -150,7 +146,7 @@ describe('tests /read/ts/since', function() {
 
 });
 
-describe('tests /read/ts/range', function() {
+/*describe('tests /read/ts/range', function() {
 	
 		it('can POST /read/ts/range and retrieve data ',function(done){
 		
@@ -173,4 +169,4 @@ describe('tests /read/ts/range', function() {
 						done();
 					});
 		});
-});
+});*/

--- a/test/timeseries.js
+++ b/test/timeseries.js
@@ -4,12 +4,12 @@ var assert = require('assert');
 
 
 describe('Add and retrieve latest TS values', function() {
-	it("Adds records posted to /write/ts", function(done) {
+	it("Adds records posted to :datasourceid/ts", function(done) {
 		var data = {
 	    	"data": 42,
 		}; 
 		supertest
-			.post("/write/ts/"+11)
+			.post("/"+11+"/ts")
 			.send(data)
 			.expect(200)
 			.end(function(err,result){
@@ -18,12 +18,9 @@ describe('Add and retrieve latest TS values', function() {
 			});
 	});
 
-	it("retrieves latest records with /read/ts/latest", function(done) {
-		var data = {
-		}; 
+	it("Retrieves latest records with :datasourceid/ts/latest", function(done) {
 		supertest
-			.post("/read/ts/"+11+'/latest')
-			.send(data)
+			.get("/"+11+'/ts/latest')
 			.expect(200)
 			.end(function(err,result){
 				if(err) {


### PR DESCRIPTION
Makes the API work better with hypercat and path-based permissions. Changes:

- The datasourceid has been moved to the fist part of the path
- /read and /write has been removed this is enforced using POST and GET instead. 
- all params are now passed in the path rather than as post data
