### PR TITLE
Bring WS sub events up to spec and disallow plain WS

### DIFF
--- a/src/lib/macaroon/macaroon-verifier.js
+++ b/src/lib/macaroon/macaroon-verifier.js
@@ -183,6 +183,11 @@ module.exports.verifier = function (secret, storeName) {
 module.exports.wsVerifier = function (secret, storeName) {
 	// TODO: See me-box/databox-store-blob issue #19
 	return function (info, callback) {
+		if (!info.secure) {
+			callback(false, 426, 'Connection must be over secure WebSockets');
+			return;
+		}
+
 		// Extract token as per Hypercat PAS 212 7.1 for uniformity
 		var creds = basicAuth(info);
 		var macaroon = info.req.headers['x-api-key'] || (creds && creds.name);

--- a/src/lib/macaroon/macaroon-verifier.js
+++ b/src/lib/macaroon/macaroon-verifier.js
@@ -205,6 +205,8 @@ module.exports.wsVerifier = function (secret, storeName) {
 		// Verify "target" caveat
 		macaroon.satisfyExact("target = " + storeName);
 
+		macaroon.satisfyExact("method = " + info.req.method);
+
 		macaroon.satisfyGeneral(createPathVerifier(url.parse(info.req.url).pathname));
 
 		// TODO: Verify granularity etc here (or potentially in tandem with driver)?


### PR DESCRIPTION
- Disallows plain WS in favour of secure WS
- Satisfies the `method` caveat which I had added to normal requests, but neglected to for WS connections. Because of this, all WS handshakes were being rejected, but now not anymore. Really I should write unit tests to catch when things like this happen and take out the `NO_SECURITY` hack, but maybe later.
- `node-databox` update to match incoming