### PR TITLE
Update key-value endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # databox-store-blob
 
-Databox Store for JSON data blobs handles time series and key value data. 
+Databox Store for JSON data blobs handles time series and key value data.
 
 The datastore exposes an HTTP-based API on port 8080 and a WebSocket based API for live data. All requests must have arbiter tokens passed as per section 7.1 of the [Hypercat 3.0 specs](https://shop.bsigroup.com/upload/276605/PAS212-corr.pdf). 
 
@@ -29,9 +29,9 @@ The datastore exposes an HTTP-based API on port 8080 and a WebSocket based API f
     
 ###Key value pairs
 
-    URL: /<key>/key/
+    URL: /<key>/kv/
     Method: GET
-    Parameters: replace <key> with document key 
+    Parameters: replace <key> with document key
     Notes: will return the data stored with that key. Returns an empty array 404 {status:404,error:"Document not found."} if no data is stored
 
 ###Websockets 
@@ -48,7 +48,7 @@ Connect to a websocket client to `/ws`. Then subscribe for data using:
     
     For key value:  
 
-    URL: /sub/<key>/key
+    URL: /sub/<key>/kv
     Method: GET
     Parameters: replace <key> with document key 
     Notes:  Will broadcast over the websocket the data stored with that key when it is add or updated. 
@@ -97,7 +97,7 @@ Connect to a websocket client to `/ws`. Then subscribe for data using:
     
 ###Key value pairs
 
-    URL: /<key>/key/
+    URL: /<key>/kv/
     Method: POST
     Parameters: Raw JSON body containing elements as follows {<data to be stored in JSON format>}
     Notes: will insert if the <key> is not in the database and update the document if it is.

--- a/src/keyvalue.js
+++ b/src/keyvalue.js
@@ -50,7 +50,7 @@ module.exports.api = function (subscriptionManager) {
 			res.send(affectedDocuments.data);
 		});
 
-		subscriptionManager.emit('/' + key + '/key', {
+		subscriptionManager.emit('/' + key + '/kv', {
 			datasource_id: key,
 			data: data,
 		});

--- a/src/main.js
+++ b/src/main.js
@@ -74,7 +74,7 @@ macaroonVerifier.getSecretFromArbiter(ARBITER_KEY)
 
 		app.use('/:datasourceid/ts/:cmd?/:timestamp?/:endtimestamp?', timeseries.api(subscriptionManager));
 
-		app.use('/:key/json/',   keyvalue.api(subscriptionManager));
+		app.use('/:key/kv/', keyvalue.api(subscriptionManager));
 
 		app.use('/sub',   subscriptionManager.sub());
 		app.use('/unsub', subscriptionManager.unsub());

--- a/test/keyvalue.js
+++ b/test/keyvalue.js
@@ -16,9 +16,9 @@ describe('Add and retrieve by key', function() {
     var data2 = {test:"data", hello:"world", goodby:'world'}; 
     var key = Date.now();
 	
-    it("Handles invalid key on read /json", function(done) {
+    it("Handles invalid key on read /kv", function(done) {
 		supertest
-			.get("/asdfgfhjkl/json/")
+			.get("/asdfgfhjkl/kv/")
 			.expect(500)
 			.end((err,result)=>{
 				//assert.deepEqual(result.body, {status:404,error:"Document not found."});
@@ -26,9 +26,9 @@ describe('Add and retrieve by key', function() {
 			});
 	})
 
-    it("Adds records posted to :key/json/", function(done) {
+    it("Adds records posted to :key/kv/", function(done) {
 		supertest
-			.post("/"+key+"/json/")
+			.post("/"+key+"/kv/")
 			.send(data)
 			.expect(200)
 			.end((err,result)=>{
@@ -37,10 +37,10 @@ describe('Add and retrieve by key', function() {
 			});
 	})
 
-	it("retrieves latest records with " + key + "/json/ ", function(done) {
+	it("retrieves latest records with " + key + "/kv/ ", function(done) {
 		
 		supertest
-			.get("/"+key+"/json/")
+			.get("/"+key+"/kv/")
 			.expect(200)
 			.end(function(err,result){
 				if(err) {
@@ -53,9 +53,9 @@ describe('Add and retrieve by key', function() {
 			});
 	});
 
-    it("Updates records posted to :key/json", function(done) {
+    it("Updates records posted to :key/kv", function(done) {
 		supertest
-			.post("/"+key+"/json")
+			.post("/"+key+"/kv")
 			.send(data2)
 			.expect(200)
 			.end((err,result)=>{
@@ -64,10 +64,10 @@ describe('Add and retrieve by key', function() {
 			});
 	});
 
-    it("retrieves latest records with /" + key + "/json/", function(done) {
+    it("retrieves latest records with /" + key + "/kv/", function(done) {
 		
 		supertest
-			.get("/"+key+"/json")
+			.get("/"+key+"/kv")
 			.expect(200)
 			.end(function(err,result){
 				if(err) {


### PR DESCRIPTION
I'm surprised that these bugs managed to survive as long as they did. When we changed the key-value endpoint from `/json` to `/key` (or the other way around; not sure anymore), half of the instances were still the old one. Found this while actually trying to interface with key-value stores.

Since the only way this could have gone undetected is because nobody was using it, I took this opportunity to change it one last time to `/kv` so that it's consistent with `/ts`. The fact that it wasn't has always irked me for some reason.

This does not affect current CM in any way, since that grants wildcard read or write to both `/ts` and `/kv`. Updating `node-databox` in a few seconds to match.