### PR TITLE
Move to mongodb (For discussion DNM)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - "6"
 env:
   NO_SECURITY=1
+services:
+  - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
+sudo: required
 language: node_js
 node_js:
   - "6"
-env:
-  NO_SECURITY=1
 services:
-  - mongodb
+  - docker
+script:
+- npm run build
+- npm run testincont

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
-FROM node:alpine
+FROM alpine:edge
 
-ADD package.json package.json
+RUN \
+echo http://dl-4.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+apk add --no-cache mongodb && \
+apk add --no-cache nodejs-current-npm && \
+rm /usr/bin/mongoperf
+
+VOLUME /database
+
+#ADD package.json package.json
+ADD . .
 RUN npm install && npm run clean
 
-ADD . .
-
 LABEL databox.type="store"
-
-VOLUME ["/database"]
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # databox-store-blob
 
-Databox Store for JSON data blobs handles time series and key value data.
+Databox Store for JSON data blobs handles time series and key value data. Based on mongoDB.
 
 The datastore exposes an HTTP-based API on port 8080 and a WebSocket based API
 for live data. All requests must have arbiter tokens passed as per section 7.1
@@ -32,9 +32,9 @@ of the
 
     URL: /<datasourceid>/query
     method: GET
-    Body Parameters: <query> a string containing a nedb json query 
+    Body Parameters: <query> a string containing a mongoDB json query 
     Body Parameters: <limit> an integer max number of documents to return 
-    Body Parameters: <sort> a string containing a nedb json sort object
+    Body Parameters: <sort> a string containing a mongoDB json sort object
     Notes: returns an array of documents 
     
 ### Key value pairs
@@ -149,5 +149,6 @@ Then restart the container manger to use you updated version.
 
 ## Testing
 
-    npm install --development
-    NO_SECURITY=1 NO_LOGGING=1 npm test
+To test the new data store in a container with its own mongoDB instance use: 
+
+    npm run build && npm run testincont

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ of the
     Body Parameters: <startTimestamp> and <endTimestamp> for the range.
     Notes: will return the all data between the provided start and end timestamps for the provided datasourceid.
 
+    URL: /<datasourceid>/query
+    method: GET
+    Body Parameters: <query> a string containing a nedb json query 
+    Body Parameters: <limit> an integer max number of documents to return 
+    Body Parameters: <sort> a string containing a nedb json sort object
+    Notes: returns an array of documents 
+    
 ### Key value pairs
 
     URL: /<key>/kv/
@@ -96,7 +103,7 @@ Connect to a websocket client to `/ws`. Then subscribe for data using:
     URL: /<datasourceid>/ts/
     Method: POST
     Parameters: Raw JSON body containing elements as follows {data: <json blob to store>}
-    Notes: Stores a value a timestamp is added on insertion
+    Notes: If there is a timestamp field in data it is used otherwise a timestamp is added on insertion 
 
 ### Key value pairs
 

--- a/databox-manifest.json
+++ b/databox-manifest.json
@@ -25,15 +25,6 @@
     "url": "git+https://github.com/me-box/databox-store-blob.git"
   },
 
-  "network-permissions": [
-  ],
-  
-  "hardware-permissions": [
-  ],
-
-  "resource-requirements": {
-  },
-
   "volumes": [
               "/database"
   ]

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
     "registry": "localhost:5000"
   },
   "scripts": {
-    "prestart": "mongod --dbpath database --fork --logpath /dev/null",
-    "pretest": "mongod --dbpath database --fork --logpath /dev/null",
+    "prestart": "mongod --dbpath database --fork --logpath /dev/null --wiredTigerEngineConfigString=\"cache_size=50M\"",
+    "pretest": "mongod --dbpath database --fork --logpath /dev/null --wiredTigerEngineConfigString=\"cache_size=50M\"",
     "test": "NO_SECURITY=1 NO_LOGGING=1 /node_modules/mocha/bin/mocha",
+    "testincont": "docker run -t databox/databox-store-blob npm test",
     "start": "node ./src/main.js",
     "build": "docker build -t databox/databox-store-blob .",
     "deploy": "docker tag databox/databox-store-blob $npm_package_config_registry/databox-store-blob && docker push $npm_package_config_registry/databox-store-blob",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   },
   "scripts": {
     "prestart": "mongod --dbpath database --fork --logpath /dev/null --wiredTigerEngineConfigString=\"cache_size=50M\"",
-    "testwithmongo": "mongod --dbpath database --fork --logpath /dev/null --wiredTigerEngineConfigString=\"cache_size=50M\" & npm test",
+    "pretest": "mongod --dbpath database --fork --logpath /dev/null --wiredTigerEngineConfigString=\"cache_size=50M\"",
     "test": "NO_SECURITY=1 NO_LOGGING=1 /node_modules/mocha/bin/mocha",
-    "testincont": "docker run -t databox/databox-store-blob npm run testwithmongo",
+    "testincont": "docker run -t databox/databox-store-blob npm test",
     "start": "node ./src/main.js",
     "build": "docker build -t databox/databox-store-blob .",
     "deploy": "docker tag databox/databox-store-blob $npm_package_config_registry/databox-store-blob && docker push $npm_package_config_registry/databox-store-blob",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "description": "Datbox datastore for blob data",
   "config": {
-    "registry": "registry.iotdatabox.com"
+    "registry": "localhost:5000"
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha",
-    "start": "node ./src/main.js",
+    "start": "node --max-old-space-size=50  ./src/main.js",
     "build": "docker build -t databox/databox-store-blob .",
     "deploy": "docker tag databox/databox-store-blob $npm_package_config_registry/databox-store-blob && docker push $npm_package_config_registry/databox-store-blob",
     "build-arm": "docker build -f Dockerfile-arm -t databox/databox-store-blob-arm .",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "registry": "localhost:5000"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha",
-    "start": "node --max-old-space-size=50  ./src/main.js",
+    "prestart": "mongod --dbpath database --fork --logpath /dev/null",
+    "pretest": "mongod --dbpath database --fork --logpath /dev/null",
+    "test": "NO_SECURITY=1 NO_LOGGING=1 /node_modules/mocha/bin/mocha",
+    "start": "node ./src/main.js",
     "build": "docker build -t databox/databox-store-blob .",
     "deploy": "docker tag databox/databox-store-blob $npm_package_config_registry/databox-store-blob && docker push $npm_package_config_registry/databox-store-blob",
     "build-arm": "docker build -f Dockerfile-arm -t databox/databox-store-blob-arm .",
@@ -33,10 +35,10 @@
     "express": "^4.14.0",
     "macaroons.js": "^0.3.6",
     "modclean": "",
+    "mongodb": "^2.2.0",
     "nedb": "^1.8.0",
     "node-uuid": "^1.4.7",
     "path-to-regexp": "^1.7.0",
-    "promise": "^7.1.1",
     "request": "^2.75.0",
     "ws": "^1.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   },
   "scripts": {
     "prestart": "mongod --dbpath database --fork --logpath /dev/null --wiredTigerEngineConfigString=\"cache_size=50M\"",
-    "pretest": "mongod --dbpath database --fork --logpath /dev/null --wiredTigerEngineConfigString=\"cache_size=50M\"",
+    "testwithmongo": "mongod --dbpath database --fork --logpath /dev/null --wiredTigerEngineConfigString=\"cache_size=50M\" & npm test",
     "test": "NO_SECURITY=1 NO_LOGGING=1 /node_modules/mocha/bin/mocha",
-    "testincont": "docker run -t databox/databox-store-blob npm test",
+    "testincont": "docker run -t databox/databox-store-blob npm run testwithmongo",
     "start": "node ./src/main.js",
     "build": "docker build -t databox/databox-store-blob .",
     "deploy": "docker tag databox/databox-store-blob $npm_package_config_registry/databox-store-blob && docker push $npm_package_config_registry/databox-store-blob",

--- a/src/lib/databox-request/databox-macaroon-cache.js
+++ b/src/lib/databox-request/databox-macaroon-cache.js
@@ -19,7 +19,7 @@ function getMacaroon(host,path,method) {
     return new Promise((resolve, reject) => {
 
         if(macaroonCache[host+path+method]) {
-            console.log("[macaroonCache] returning cashed macaroon");
+            //console.log("[macaroonCache] returning cashed macaroon");
             //TODO check if the macaroon has expired? for now if a request fails we invalidate the macaroon
             resolve(macaroonCache[host+path+method]);
             return;

--- a/src/lib/databox-request/databox-request-promise.js
+++ b/src/lib/databox-request/databox-request-promise.js
@@ -56,7 +56,7 @@ module.exports = function (options,callback) {
         } else if (isExternalDevRequest) {
             //DEV mode external request.
             options.headers = {};
-            console.log("[databox-request] ExternalRequest " + options.uri);
+            //console.log("[databox-request] ExternalRequest " + options.uri);
             resolve(request(options,callback));
         } else if (isExternalRequest) {
             //
@@ -65,7 +65,7 @@ module.exports = function (options,callback) {
             // TODO::EXTERNAL REQUEST SHOULD BE ROOTED THROUGH THE DATABOX WHITELISTING PROXY THING (when its been written!!)
             options.headers = {};
             options.agent = undefined; //external request use the default agent.
-            console.log("[databox-request] ExternalRequest " + options.uri);
+            //console.log("[databox-request] ExternalRequest " + options.uri);
             resolve(request(options,callback));
         } else {
             //
@@ -75,7 +75,7 @@ module.exports = function (options,callback) {
             .then((macaroon)=>{
                 //do the request and call back when done
                 options.headers = {'X-Api-Key': macaroon};
-                console.log("[databox-request-with-macaroon] ", options.uri);
+                //console.log("[databox-request-with-macaroon] ", options.uri);
                 resolve(request(options,callback));
             })
             .catch((result)=>{

--- a/src/timeseries.js
+++ b/src/timeseries.js
@@ -1,3 +1,4 @@
+/*jshint esversion: 6 */
 const Router = require('express').Router;
 const Datastore = require('nedb');
 
@@ -8,49 +9,81 @@ db.ensureIndex({fieldName: 'timestamp', unique: false});
 // TODO: Consider OOP-ing this whole thing
 
 module.exports.api = function (subscriptionManager) {
-	var router = Router({mergeParams: true});
+	let router = Router({mergeParams: true});
 
-	var latest = function (req, res, next) {
-		var datasource_id = req.params.datasourceid;
+	const latest = function (req, res, next) {
+		const datasource_id = req.params.datasourceid;
 		db.find({ datasource_id: datasource_id }).sort({ timestamp: -1 }).limit(1).exec(function (err, doc) {
 			if (err) {
 				console.log('[Error]::', req.originalUrl);
 				// TODO: Status code + document
-				res.send(err);
+				res.status(400).send(err);
 				return
 			}
 			res.send(doc);
 		});
 	};
 
-	var since = function (req, res, next) {
-		var datasource_id = req.params.datasourceid;
-		var timestamp = req.body.startTimestamp;
+	const since = function (req, res, next) {
+		const datasource_id = req.params.datasourceid;
+		const timestamp = req.body.startTimestamp;
 		db.find({ datasource_id, $where: function () { return this.timestamp >= timestamp; } }).sort({ timestamp: 1 }).exec(function (err, doc) {
 			if (err) {
 				console.log('[Error]::', req.originalUrl, timestamp);
 				// TODO: Status code + document
-				res.send(err);
+				res.status(400).send(err);
 				return;
 			}
 			res.send(doc);
 		});
 	};
 
-	var range = function (req, res, next) {
-		var datasource_id = req.params.datasourceid;
-		var start = req.body.startTimestamp;
-		var end = req.body.endTimestamp;
+	const range = function (req, res, next) {
+		const datasource_id = req.params.datasourceid;
+		const start = req.body.startTimestamp;
+		const end = req.body.endTimestamp;
 
 		db.find({ datasource_id, $where: function () { return this.timestamp >= start && this.timestamp <= end; } }).sort({ timestamp: 1 }).exec(function (err, doc) {
 			if (err) {
 				console.log('[Error]::', req.originalUrl, timestamp);
 				// TODO: Status code + document
-				res.send(err);
+				res.status(400).send(err);
 				return;
 			}
 			res.send(doc);
 		});
+	};
+
+	const index = function (req, res, next) {
+		const indexName = req.body.index;
+		db.ensureIndex({ fieldName: indexName }, function (err) {
+			if (err) {
+				console.log('[Error]::', req.originalUrl, timestamp);
+				res.status(400).send(err);
+				return;
+			}
+			res.send();
+		});
+	};
+
+	const query = function (req, res, next) {
+		try{
+			const query = JSON.parse(req.body.query);
+			const limit = req.body.limit || -1;
+			const sort = JSON.parse(req.body.sort || '{}');
+			console.log(query);
+			db.find(query).sort(sort).limit(limit).exec(function (err,docs) {
+				if (err) {
+					console.log('[Error]::', req.originalUrl, timestamp);
+					res.status(400).send(err);
+					return;
+				}
+				res.send(docs);
+			});
+		} catch (e) {
+			console.log('[Error]:: bad query',e);
+			res.status(400).send('[Error]:: bad query');
+		}
 	};
 
 	router.get('/', function (req, res, next) {
@@ -65,22 +98,37 @@ module.exports.api = function (subscriptionManager) {
 		if(cmd == 'range') {
 			range(req, res, next);
 		}
+		if(cmd == 'index') {
+			index(req, res, next);
+		}
+		if(cmd == 'query') {
+			query(req, res, next);
+		}
 		
 	});
 
 	// TODO: .all, see #15
 	router.post('/', function (req, res, next) {
+		
+		//trust the drivers timestamp
+		let timestamp = null;
+		if(req.body.timestamp && Number.isInteger(req.body.timestamp)) {
+			timestamp = req.body.timestamp;
+		} else {
+			timestamp = Date.now();
+		}
+		
 		var data = {
 			datasource_id: req.params.datasourceid,
 			'data': req.body.data,
-			'timestamp': Date.now()
+			'timestamp': timestamp
 		};
 
 		db.insert(data, function (err, doc) {
 			if (err) {
 				console.log('[Error]::', req.originalUrl, data, err);
 				// TODO: Status code + document
-				res.send(err);
+				res.status(400).send(err);
 				return;
 			}
 			res.send(doc);

--- a/test/load.js
+++ b/test/load.js
@@ -1,0 +1,28 @@
+
+//used to test mem usage with lots of records take 20s to run so commented out usually 
+
+/*var app = require("../src/main.js");
+var supertest = require("supertest")(app);
+var assert = require('assert');
+
+describe('tests load', function() {
+
+    var ts = Date.now();
+    var data = {
+	    	"data": {test:"data", hello:"world",testing:[1,2,3,43,56,7,7,8]},
+		};
+    
+    for(let i=0; i<10000; i++) {
+        it("Adds records posted to :datasourceid/ts", function(done) { 
+            data.timestamp = ts + i;
+            supertest
+                .post("/"+11+"/ts/")
+                .send(data)
+                .expect(200)
+                .end(function(err,result){
+                    assert.deepEqual(result.body.data, {test:"data", hello:"world",testing:[1,2,3,43,56,7,7,8]});
+                    done();
+                });
+        });
+    }
+});*/

--- a/test/timeseries-data-since.js
+++ b/test/timeseries-data-since.js
@@ -5,12 +5,12 @@ var assert = require('assert');
 
 
 var recordSet = []; // store res from can POST /data/since to test /data/range
+var lastRecord = {};
 
 describe('tests /ts/since', function() {
 	var data = {
 	    	"data": {new:"data", since:"world"},
 		}; 
-	var lastRecord = {};
 	
 	it("Adds records posted to :timestamp/ts", function(done) {
 		var data = {
@@ -38,8 +38,8 @@ describe('tests /ts/since', function() {
 					}
 					assert.deepEqual(result.body[0].data, {test:"data", hello:"world"});
 					lastRecord = result.body[0];
-					done();
 					console.log(lastRecord.timestamp);
+					done();
 				});
 	});
 
@@ -123,9 +123,12 @@ describe('tests /ts/since', function() {
 			.expect(200)
 			.end(function(err,result){
 				assert.deepEqual(result.body.data, {test:"data", hello:"world4"});
+					console.log("TOSH::",lastRecord.timestamp);
+
 				done();
 			});
 	});
+
 
 	it('can GET /ts/since with startTimestamp ' + lastRecord.timestamp  + ' and returns 6 items',function(done){
 		supertest
@@ -133,8 +136,9 @@ describe('tests /ts/since', function() {
 				.send({
 					startTimestamp: lastRecord.timestamp
 				})
-				.expect(200)
+				//.expect(200)
 				.end(function(err,result){
+					console.log("TOSH2::",lastRecord.timestamp);
 					if(err) {
 						assert.fail("","",err);
 						done();

--- a/test/timeseries-query.js
+++ b/test/timeseries-query.js
@@ -1,0 +1,77 @@
+var app = require("../src/main.js");
+var supertest = require("supertest")(app);
+var assert = require('assert');
+
+describe('tests /ts/query', function() {
+
+    var ts = Date.now();
+    var data = {
+	    	"data": {test:"data", hello:"world"},
+		};
+    
+    for(let i=0; i<10; i++) {
+        it("Adds records posted to :datasourceid/ts", function(done) { 
+            data.timestamp = ts + i;
+            supertest
+                .post("/"+11+"/ts/")
+                .send(data)
+                .expect(200)
+                .end(function(err,result){
+                    assert.deepEqual(result.body.data, {test:"data", hello:"world"});
+                    done();
+                });
+        });
+    }
+
+    it("Adds index :datasourceid/ts/index", function(done) { 
+        supertest
+                .get("/"+11+"/ts/index")
+                .send({index:'data.test'})
+                .expect(200)
+                .end(function(err,result){
+                    done();
+                });
+    });
+
+    it("gets docs from query :datasourceid/ts/query", function(done) { 
+        supertest
+                .get("/"+11+"/ts/query")
+                .send({query: JSON.stringify({ 'data.test': 'data' })})
+                .expect(200)
+                .end(function(err,result){
+                    assert.equal(true, result.body.length >= 10);
+                    done();
+                });
+    });
+
+    it("gets docs from query with limit :datasourceid/ts/query", function(done) { 
+        supertest
+                .get("/"+11+"/ts/query")
+                .send({query: JSON.stringify({ 'data.test': 'data' }), limit:5})
+                .expect(200)
+                .end(function(err,result){
+                    assert.equal(true, result.body.length == 5);
+                    done();
+                });
+    });
+
+    it("gets docs from query with limit and sort :datasourceid/ts/query", function(done) { 
+        supertest
+                .get("/"+11+"/ts/query")
+                .send(
+                      { 
+                        query: JSON.stringify({ 'data.test': 'data' }), 
+                        limit:5, 
+                        sort:JSON.stringify({'timestamp':-1})
+                      }
+                     )
+                .expect(200)
+                .end(function(err,result){
+                    assert.equal(true, result.body.length == 5);
+                    done();
+                });
+    });
+
+
+
+});


### PR DESCRIPTION
This PR removes nedb in favour of MongoDB.

Nedb was fine for small data sets however it holds the full DB in RAM as a json object. This means a 150 MB (on disk) location dataset used 1.5GB of RAM when imported. This is not Ideal ;-) see https://github.com/louischatriot/nedb/issues/506

Moving to Mongo DB has a negative impact on Image size (80MB to 120MB) and startup RAM usage (90MB to 120MB) but the RAM usage is stable as the dataset grows. Ram usages could also be optimised by tweaking mongoDB's config file. 

Another issue is that there is no armhf package for mongo only arm64. There is a community build here http://andyfelong.com/2017/03/mongodb-3-0-14-binaries-for-raspberry-pi-3/ which might work. But I've not had time to test his yet.

Should we kill the old blob store and move to mongo or do a mongo backed version? We need something stable for larger datassets for the next set of demos. 
